### PR TITLE
Make webcam examples work in Firefox

### DIFF
--- a/Three.js/Webcam-Motion-Detection-Texture.html
+++ b/Three.js/Webcam-Motion-Detection-Texture.html
@@ -28,7 +28,7 @@
 <div id="messageArea" style="position: relative; left: 0px; top: 270px;"></div>
 <div id="container" style="position: absolute; left:0px; top:0px"></div>
 <script>
-navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.getUserMedia;
+navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 window.URL = window.URL || window.webkitURL;
 
 var camvideo = document.getElementById('monitor');

--- a/Three.js/Webcam-Motion-Detection.html
+++ b/Three.js/Webcam-Motion-Detection.html
@@ -36,7 +36,7 @@
 </script>
 
 <script>
-navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.getUserMedia;
+navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 window.URL = window.URL || window.webkitURL;
 
 var camvideo = document.getElementById('monitor');

--- a/Three.js/Webcam-Test.html
+++ b/Three.js/Webcam-Test.html
@@ -33,7 +33,7 @@ Video on left, Canvas on right.
 </script>
 
 <script>
-navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.getUserMedia;
+navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 window.URL = window.URL || window.webkitURL;
 
 var camvideo = document.getElementById('monitor');

--- a/Three.js/Webcam-Texture.html
+++ b/Three.js/Webcam-Texture.html
@@ -23,7 +23,7 @@
 <canvas id="videoImage" width="160" height="120" style="visibility: hidden; float:left;"></canvas>
 
 <script>
-navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.getUserMedia;
+navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 window.URL = window.URL || window.webkitURL;
 
 var camvideo = document.getElementById('monitor');
@@ -32,9 +32,9 @@ var camvideo = document.getElementById('monitor');
 	{
 		document.getElementById('errorMessage').innerHTML = 
 			'Sorry. <code>navigator.getUserMedia()</code> is not available.';
-		return;
+	} else {
+		navigator.getUserMedia({video: true}, gotStream, noStream);
 	}
-	navigator.getUserMedia({video: true}, gotStream, noStream);
 
 function gotStream(stream) 
 {


### PR DESCRIPTION
Now that Firefox has WebRTC enabled by default... what better than having the examples work with Firefox? :-)

I added the prefixes (hopefully these will be dropped at some point), and fixed an extra return outside a function in `Webcam-Texture.html` that gave a compilation error and thus the script wouldn't run, at all.

Enjoy!! :+1: 
