### PR TITLE
Fix Parametric Curve Graphing Range

### DIFF
--- a/Three.js/Graphulus-Curve.html
+++ b/Three.js/Graphulus-Curve.html
@@ -88,7 +88,7 @@ Knot = THREE.Curve.create(
 	{
 		// default:    0 < t < 1
 		//    want: tMin < t < tMax
-        tRange = tMax - tMin;
+		tRange = tMax - tMin;
 		t = t * tRange + tMin;
 		return new THREE.Vector3(xFunc(t), yFunc(t), zFunc(t)).multiplyScalar(1);
 	}

--- a/Three.js/Graphulus-Curve.html
+++ b/Three.js/Graphulus-Curve.html
@@ -66,7 +66,7 @@ var segments = 120;
 var radiusSegments = 6;
 var tubeRadius = 0.1;
 
-var tMin = -2.11, tMax = 2.11, tRange = tMax - tMin;
+var tMin = -2.11, tMax = 2.11;
 
 var xFuncText = "t^3 - 3*t";
 var yFuncText = "t^4 - 4*t^2";
@@ -88,6 +88,7 @@ Knot = THREE.Curve.create(
 	{
 		// default:    0 < t < 1
 		//    want: tMin < t < tMax
+        tRange = tMax - tMin;
 		t = t * tRange + tMin;
 		return new THREE.Vector3(xFunc(t), yFunc(t), zFunc(t)).multiplyScalar(1);
 	}


### PR DESCRIPTION
Before, parametric functions were not graphed on the correct range of t values. The range was always `tMin < t < tMin + 4.1` instead of `tMin < t < tMax`.

Note: I'm new to Three.js, and I don't know if what I did was the best way to fix the bug.


