### PR TITLE
Fix for texture animation

### DIFF
--- a/Three.js/Texture-Animation.html
+++ b/Three.js/Texture-Animation.html
@@ -188,7 +188,7 @@ function TextureAnimator(texture, tilesHoriz, tilesVert, numTiles, tileDispDurat
 			var currentColumn = this.currentTile % this.tilesHorizontal;
 			texture.offset.x = currentColumn / this.tilesHorizontal;
 			var currentRow = Math.floor( this.currentTile / this.tilesHorizontal );
-			texture.offset.y = currentRow / this.tilesVertical;
+			texture.offset.y = ( - currentRow - 1 ) / this.tilesVertical;
 		}
 	};
 }		


### PR DESCRIPTION
When a texture animation has multiple rows, like the explosion boomer, it was cycling through the frames in the wrong order. This fix starts with the top row and moves down, instead of starting with the bottom row and moving up. Tile 0 is now the top left, rather than the bottom left.
